### PR TITLE
Escape Pipe to Avoid Creating A Table

### DIFF
--- a/_posts/2020-07-02-july-2nd-2020.md
+++ b/_posts/2020-07-02-july-2nd-2020.md
@@ -13,4 +13,4 @@ title: The Wolf Report - July 2nd, 2020
 - [Handling webhooks with EventBridge, SAM and SAR - DEV](https://dev.to/aws-heroes/handling-webhooks-with-eventbridge-sam-and-sar-ac3)
 - [r2c blog — Hardcoded secrets, unverified tokens, and other common JWT mistakes](https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/)
 - [Creating a Multi-Tenant ASP.NET Core Web API with Dapper and SQL RLS - Building SPAs](https://www.carlrippon.com/creating-an-aspnetcore-multi-tenant-web-api-with-dapper-and-sql-rls/)
-- [Twitch - Amazon DynamoDB | Office Hours with Rick Houlihan](https://www.twitch.tv/videos/666408350)
+- [Twitch - Amazon DynamoDB \| Office Hours with Rick Houlihan](https://www.twitch.tv/videos/666408350)


### PR DESCRIPTION
The pipe character here inside the square brackets of the link will create a table. Escape it to avoid this.

See:
 - "Kramdown bug - pipe character in Markdown link creates a table #2818" https://github.com/jekyll/jekyll/issues/2818
 - "Kramdown Syntax - Automatic and Manual Escaping" https://kramdown.gettalong.org/syntax.html#automatic-and-manual-escaping