### PR TITLE
Update an old post to directly link to page rather than redirect

### DIFF
--- a/_posts/2020-02-07-february-7th-2020.md
+++ b/_posts/2020-02-07-february-7th-2020.md
@@ -25,4 +25,4 @@ title: The Wolf Report - February 7th, 2020
 - [TypeScript: Assertion signatures and Object.defineProperty](https://fettblog.eu/typescript-assertion-signatures/)
 - [State versioning in Orleans](https://blog.ulriksen.net/state-versioning-in-orleans/)
 - [Babel F# pipeline operator &#8211; Code Reform](http://codereform.com/blog/post/babel-fsharp-pipeline-operator/)
-- [Demystifying a TypeScript quirk - Me4502](https://matthewmiller.dev/blog/demystifying-typescript-quirk/)
+- [Demystifying a TypeScript quirk - Me4502](https://madelinemiller.dev/blog/demystifying-typescript-quirk/)


### PR DESCRIPTION
I switched URLs a fair while ago, so just updating the old post to reference the new one. Thanks :) 